### PR TITLE
mspm0: CmakeLists: link and compile dl_timer.c

### DIFF
--- a/mspm0/CMakeLists.txt
+++ b/mspm0/CMakeLists.txt
@@ -19,5 +19,6 @@ if(CONFIG_HAS_MSPM0SDK)
     source/ti/driverlib/dl_vref.c
     source/ti/driverlib/dl_mcan.c
     source/ti/driverlib/m0p/sysctl/dl_sysctl_mspm0g1x0x_g3x0x.c
+    source/ti/driverlib/dl_timer.c
     )
 endif()


### PR DESCRIPTION
Needed to use hardware clocks/timers