### PR TITLE
spi: add dl_spi.c as library source

### DIFF
--- a/mspm0/CMakeLists.txt
+++ b/mspm0/CMakeLists.txt
@@ -18,6 +18,7 @@ if(CONFIG_HAS_MSPM0SDK)
     source/ti/driverlib/dl_adc12.c
     source/ti/driverlib/dl_vref.c
     source/ti/driverlib/dl_mcan.c
+    source/ti/driverlib/dl_spi.c
     source/ti/driverlib/m0p/sysctl/dl_sysctl_mspm0g1x0x_g3x0x.c
     )
 endif()


### PR DESCRIPTION
This commit adds dl_spi.c as library source when building for mspm0.